### PR TITLE
Adding overwrite-able working directories

### DIFF
--- a/src/gerber2ems/config.py
+++ b/src/gerber2ems/config.py
@@ -215,15 +215,12 @@ class Config:
         self.arguments = args
 
         # Create the working directories
-        self.base_dir = self.create_dir(path = BASE_DIR, cleanup = False)
-        if args.geometry or args.all:
-            self.geometry_dir = self.create_dir(path = GEOMETRY_DIR, cleanup = True)
-        if args.postprocess or args.all:
-            self.results_dir = self.create_dir(path = RESULTS_DIR, cleanup = True)
-        if args.simulate or args.all:
-            self.simulation_dir = self.create_dir(path = SIMULATION_DIR, cleanup = True)
+        self.base_dir = os.path.join(os.getcwd(), BASE_DIR)
+        self.geometry_dir = os.path.join(os.getcwd(), GEOMETRY_DIR)
+        self.results_dir = os.path.join(os.getcwd(), RESULTS_DIR)
+        self.simulation_dir = os.path.join(os.getcwd(), SIMULATION_DIR)
 
-        # Assign the dab directory
+        # Assign the fab directory
         self.fab_dir = os.path.join(os.getcwd(), "fab")
 
         ports = get(json, ["ports"], list)
@@ -247,6 +244,18 @@ class Config:
         self.layers: List[LayerConfig] = []
 
         self.__class__._instance = self
+
+    def create_default_directories(self) -> None:
+        # Create the working directories. 
+        # Create from constants to keep track of not removing any
+        # important files. 
+        self.base_dir = self.create_dir(path = BASE_DIR, cleanup = False)
+        if self.arguments.geometry or self.arguments.all:
+            self.geometry_dir = self.create_dir(path = GEOMETRY_DIR, cleanup = True)
+        if self.arguments.postprocess or self.arguments.all:
+            self.results_dir = self.create_dir(path = RESULTS_DIR, cleanup = True)
+        if self.arguments.simulate or self.arguments.all:
+            self.simulation_dir = self.create_dir(path = SIMULATION_DIR, cleanup = True)
 
     def load_stackup(self, stackup) -> None:
         """Load stackup from json object."""

--- a/src/gerber2ems/importer.py
+++ b/src/gerber2ems/importer.py
@@ -34,7 +34,7 @@ def process_gbrs_to_pngs():
     """
     logger.info("Processing gerber files")
 
-    files = os.listdir(os.path.join(os.getcwd(), "fab"))
+    files = os.listdir(os.path.join(Config.get().fab_dir))
 
     edge = next(filter(lambda name: "Edge_Cuts.gbr" in name, files), None)
     if edge is None:
@@ -48,8 +48,8 @@ def process_gbrs_to_pngs():
     for name in layers:
         output = name.split("-")[-1].split(".")[0] + ".png"
         gbr_to_png(
-            os.path.join(os.getcwd(), "fab", name),
-            os.path.join(os.getcwd(), "fab", edge),
+            os.path.join(Config.get().fab_dir, name),
+            os.path.join(Config.get().fab_dir, edge),
             os.path.join(Config.get().geometry_dir, output),
         )
 
@@ -158,7 +158,7 @@ def get_vias() -> List[List[float]]:
     Looks for excellon file in `fab` directory. Its filename should end with `-PTH.drl`
     It then processes it to find all vias.
     """
-    files = os.listdir(os.path.join(os.getcwd(), "fab"))
+    files = os.listdir(os.path.join(Config.get().fab_dir))
     drill_filename = next(filter(lambda name: "-PTH.drl" in name, files), None)
     if drill_filename is None:
         logger.error("Couldn't find drill file")
@@ -167,7 +167,7 @@ def get_vias() -> List[List[float]]:
     drills = {0: 0.0}  # Drills are numbered from 1. 0 is added as a "no drill" option
     current_drill = 0
     vias: List[List[float]] = []
-    with open(os.path.join(os.getcwd(), "fab", drill_filename), "r", encoding="utf-8") as drill_file:
+    with open(os.path.join(Config.get().fab_dir, drill_filename), "r", encoding="utf-8") as drill_file:
         for line in drill_file.readlines():
             # Regex for finding drill sizes (in mm)
             match = re.fullmatch("T([0-9]+)C([0-9]+.[0-9]+)\\n", line)
@@ -201,7 +201,7 @@ def get_vias() -> List[List[float]]:
 
 def import_stackup():
     """Import stackup information from `fab/stackup.json` file and load it into config object."""
-    filename = "fab/stackup.json"
+    filename = Config.get().fab_dir + "/stackup.json"
     with open(filename, "r", encoding="utf-8") as file:
         try:
             stackup = json.load(file)
@@ -236,9 +236,9 @@ def import_port_positions() -> None:
     Parses them to find port footprints and inserts their position information to config object.
     """
     ports: List[Tuple[int, Tuple[float, float], float]] = []
-    for filename in os.listdir(os.path.join(os.getcwd(), "fab")):
+    for filename in os.listdir(os.path.join(Config.get().fab_dir)):
         if filename.endswith("-pos.csv"):
-            ports += get_ports_from_file(os.path.join(os.getcwd(), "fab", filename))
+            ports += get_ports_from_file(os.path.join(Config.get().fab_dir, filename))
 
     for number, position, direction in ports:
         if len(Config.get().ports) > number:

--- a/src/gerber2ems/importer.py
+++ b/src/gerber2ems/importer.py
@@ -16,7 +16,6 @@ import matplotlib.pyplot as plt
 
 from gerber2ems.config import Config
 from gerber2ems.constants import (
-    GEOMETRY_DIR,
     UNIT,
     PIXEL_SIZE,
     BORDER_THICKNESS,
@@ -51,7 +50,7 @@ def process_gbrs_to_pngs():
         gbr_to_png(
             os.path.join(os.getcwd(), "fab", name),
             os.path.join(os.getcwd(), "fab", edge),
-            os.path.join(os.getcwd(), GEOMETRY_DIR, output),
+            os.path.join(Config.get().geometry_dir, output),
         )
 
 
@@ -92,7 +91,7 @@ def get_dimensions(input_filename: str) -> Tuple[int, int]:
     Opens PNG found in `ems/geometry` directory,
     gets it's size and subtracts border thickness to get board dimensions
     """
-    path = os.path.join(GEOMETRY_DIR, input_filename)
+    path = os.path.join(Config.get().geometry_dir, input_filename)
     image = PIL.Image.open(path)
     image_width, image_height = image.size
     height = image_height * PIXEL_SIZE - BORDER_THICKNESS
@@ -109,7 +108,7 @@ def get_triangles(input_filename: str) -> np.ndarray:
     and then uses Nanomesh to create a triangular mesh of the copper.
     Returns a list of triangles, where each triangle consists of coordinates for each vertex.
     """
-    path = os.path.join(GEOMETRY_DIR, input_filename)
+    path = os.path.join(Config.get().geometry_dir, input_filename)
     image = PIL.Image.open(path)
     gray = image.convert("L")
     thresh = gray.point(lambda p: 255 if p < 230 else 0)
@@ -123,7 +122,7 @@ def get_triangles(input_filename: str) -> np.ndarray:
     mesh = mesher.triangulate(opts="a100000")
 
     if Config.get().arguments.debug:
-        filename = os.path.join(os.getcwd(), GEOMETRY_DIR, input_filename + "_mesh.png")
+        filename = os.path.join(Config.get().geometry_dir, input_filename + "_mesh.png")
         logger.debug("Saving mesh to file: %s", filename)
         mesh.plot_mpl()
         plt.savefig(filename, dpi=300)

--- a/src/gerber2ems/main.py
+++ b/src/gerber2ems/main.py
@@ -7,12 +7,10 @@ import json
 import argparse
 import logging
 from typing import Any, Optional
-import shutil
 
 import coloredlogs
 import numpy as np
 
-from gerber2ems.constants import BASE_DIR, SIMULATION_DIR, GEOMETRY_DIR, RESULTS_DIR
 from gerber2ems.simulation import Simulation
 from gerber2ems.postprocess import Postprocesor
 from gerber2ems.config import Config
@@ -39,20 +37,16 @@ def main():
 
     config = open_config(args)
     config = Config(config, args)
-    create_dir(BASE_DIR)
 
     if args.geometry or args.all:
         logger.info("Creating geometry")
-        create_dir(GEOMETRY_DIR, cleanup=True)
         sim = Simulation()
         geometry(sim)
     if args.simulate or args.all:
         logger.info("Running simulation")
-        create_dir(SIMULATION_DIR, cleanup=True)
         simulate(threads=args.threads)
     if args.postprocess or args.all:
         logger.info("Postprocessing")
-        create_dir(RESULTS_DIR, cleanup=True)
         sim = Simulation()
         postprocess(sim)
 
@@ -244,14 +238,6 @@ def open_config(args: Any) -> None:
 
     return config
 
-
-def create_dir(path: str, cleanup: bool = False) -> None:
-    """Create a directory if doesn't exist."""
-    directory_path = os.path.join(os.getcwd(), path)
-    if cleanup and os.path.exists(directory_path):
-        shutil.rmtree(directory_path)
-    if not os.path.exists(directory_path):
-        os.mkdir(directory_path)
 
 
 if __name__ == "__main__":

--- a/src/gerber2ems/main.py
+++ b/src/gerber2ems/main.py
@@ -37,6 +37,7 @@ def main():
 
     config = open_config(args)
     config = Config(config, args)
+    config.create_default_directories()
 
     if args.geometry or args.all:
         logger.info("Creating geometry")

--- a/src/gerber2ems/postprocess.py
+++ b/src/gerber2ems/postprocess.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import skrf
 
 from gerber2ems.config import Config
-from gerber2ems.constants import RESULTS_DIR, PLOT_STYLE
+from gerber2ems.constants import PLOT_STYLE
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +133,7 @@ class Postprocesor:
                 axes.set_xlabel("Frequency, f [GHz]")
                 axes.set_ylabel("Magnitude, [dB]")
                 axes.grid(True)
-                fig.savefig(os.path.join(os.getcwd(), RESULTS_DIR, f"S_x{i+1}.png"))
+                fig.savefig(os.path.join(Config.get().results_dir, f"S_x{i+1}.png"))
 
     def render_diff_pair_s_params(self):
         """Render differential pair S parameter plots to files."""
@@ -174,7 +174,7 @@ class Postprocesor:
                 axes.set_xlabel("Frequency, f [GHz]")
                 axes.set_ylabel("Magnitude, [dB]")
                 axes.grid(True)
-                fig.savefig(os.path.join(os.getcwd(), RESULTS_DIR, f"SDD_{pair.name}"))
+                fig.savefig(os.path.join(Config.get().results_dir, f"SDD_{pair.name}"))
 
     def render_diff_impedance(self):
         """Render differential pair impedance plots to files."""
@@ -219,7 +219,7 @@ class Postprocesor:
                     axs[1].grid(True)
 
                     fig.savefig(
-                        os.path.join(os.getcwd(), RESULTS_DIR, f"Z_diff_{pair.name}.png"),
+                        os.path.join(Config.get().results_dir, f"Z_diff_{pair.name}.png"),
                         bbox_inches="tight",
                     )
                 else:
@@ -264,7 +264,7 @@ class Postprocesor:
                     axs[0].axhline(np.real(max_z), color="red")
 
                 fig.savefig(
-                    os.path.join(os.getcwd(), RESULTS_DIR, f"Z_{port+1}.png"),
+                    os.path.join(Config.get().results_dir, f"Z_{port+1}.png"),
                     bbox_inches="tight",
                 )
 
@@ -287,7 +287,7 @@ class Postprocesor:
                     draw_vswr=[vswr_margin],
                 )
                 fig.savefig(
-                    os.path.join(os.getcwd(), RESULTS_DIR, f"S_{port+1}{port+1}_smith.png"),
+                    os.path.join(Config.get().results_dir, f"S_{port+1}{port+1}_smith.png"),
                     bbox_inches="tight",
                 )
 
@@ -307,7 +307,7 @@ class Postprocesor:
                 axes.set_xlabel("Frequency, f [GHz]")
                 axes.set_ylabel("Trace delay, [ns]")
                 axes.grid(True)
-                fig.savefig(os.path.join(os.getcwd(), RESULTS_DIR, f"{trace.name}_delay.png"))
+                fig.savefig(os.path.join(Config.get().results_dir, f"{trace.name}_delay.png"))
 
         for pair in Config.get().diff_pairs:
             if (
@@ -330,13 +330,13 @@ class Postprocesor:
                 axes.set_xlabel("Frequency, f [GHz]")
                 axes.set_ylabel("Trace delay, [ns]")
                 axes.grid(True)
-                fig.savefig(os.path.join(os.getcwd(), RESULTS_DIR, f"{pair.name}_delay.png"))
+                fig.savefig(os.path.join(Config.get().results_dir, f"{pair.name}_delay.png"))
 
     def save_to_file(self) -> None:
         """Save all parameters to files."""
         for i, _ in enumerate(self.s_params):
             if self.is_valid(self.s_params[i][i]):
-                self.save_port_to_file(i, RESULTS_DIR)
+                self.save_port_to_file(i, Config.get().results_dir)
 
     def save_port_to_file(self, port_number: int, path) -> None:
         """Save all parameters from single excitation."""

--- a/src/gerber2ems/simulation.py
+++ b/src/gerber2ems/simulation.py
@@ -13,8 +13,6 @@ import numpy as np
 from gerber2ems.config import Config, PortConfig, LayerKind
 from gerber2ems.constants import (
     UNIT,
-    SIMULATION_DIR,
-    GEOMETRY_DIR,
     VIA_POLYGON,
 )
 import gerber2ems.importer as importer
@@ -414,15 +412,15 @@ class Simulation:
         logger.info("Starting simulation")
         cwd = os.getcwd()
         if threads is not None:
-            self.fdtd.Run(os.path.join(os.getcwd(), SIMULATION_DIR, str(excited_port_number)), numThreads=threads)
+            self.fdtd.Run(os.path.join(Config.get().simulation_dir, str(excited_port_number)), numThreads=threads)
         else:
-            self.fdtd.Run(os.path.join(os.getcwd(), SIMULATION_DIR, str(excited_port_number)))
+            self.fdtd.Run(os.path.join(Config.get().simulation_dir, str(excited_port_number)))
 
         os.chdir(cwd)
 
     def save_geometry(self) -> None:
         """Save geometry to file."""
-        filename = os.path.join(os.getcwd(), GEOMETRY_DIR, "geometry.xml")
+        filename = os.path.join(Config.get().geometry_dir, "geometry.xml")
         logger.info("Saving geometry to %s", filename)
         self.csx.Write2XML(filename)
 
@@ -436,7 +434,7 @@ class Simulation:
 
     def load_geometry(self) -> None:
         """Load geometry from file."""
-        filename = os.path.join(os.getcwd(), GEOMETRY_DIR, "geometry.xml")
+        filename = os.path.join(Config.get().geometry_dir, "geometry.xml")
         logger.info("Loading geometry from %s", filename)
         if not os.path.exists(filename):
             logger.error("Geometry file does not exist. Did you run geometry step?")
@@ -445,7 +443,7 @@ class Simulation:
 
     def get_port_parameters(self, index: int, frequencies) -> Tuple[List, List]:
         """Return reflected and incident power vs frequency for each port."""
-        result_path = os.path.join(os.getcwd(), SIMULATION_DIR, str(index))
+        result_path = os.path.join(Config.get().simulation_dir, str(index))
 
         incident: List[np.ndarray] = []
         reflected: List[np.ndarray] = []


### PR DESCRIPTION
For using the gerber2ems as an API, I have wanted to have the default directories to be more flexible. 
Therefore, this PR changes the behavior of the default locations, moving them from constants to the config class, such that it's possible to overwrite them. 

Note that the stackup and config file still needs to be in the same directory as the gerber files, but I think that is a reasonable compromise as to not disrupt the source too much. 